### PR TITLE
Comments-related QoL flags.

### DIFF
--- a/filecheckize/main.py
+++ b/filecheckize/main.py
@@ -36,14 +36,17 @@ def main():
     )
     parser.add_argument(
         "--strip-comments",
-        action="store_true",
-        help="Strip comments from input rather than checking for them.",
+        type=str,
+        nargs="?",
+        default="",
+        const="//",
+        help="Strip comments from input rather than checking for them. Can take a custom comment prefix, otherwise defaults to // as in MLIR",
     )
     parser.add_argument(
         "--comments-prefix",
         type=str,
         default="//",
-        help="Set the prefix of a comment line. Defaults to '//' as in MLIR.",
+        help="Set the comment prefix to generate. defaults to '//' as in MLIR.",
     )
     parser.add_argument(
         "--check-prefix",
@@ -54,12 +57,13 @@ def main():
 
     args = parser.parse_args(sys.argv[1:])
 
-    comment_line = re.compile(rf"^\s*{re.escape(args.comments_prefix)}.*$")
+    comment_line = re.compile(rf"^\s*{re.escape(args.strip_comments)}.*$")
     unnamed_ssa_value = re.compile(r"%([\d]+)")
     ssa_value_name = re.compile(r"%([\d]+|[\w$._-][\w\d$._-]*)(:|#[\d]*)?")
     basic_block_name = re.compile(r"\^([\d]+|[\w$._-][\w\d$._-]*)")
 
     prefix = args.check_prefix
+    comm = args.comments_prefix
 
     next = False
 
@@ -69,7 +73,7 @@ def main():
         # Ignore whitespace-only lines
         if not line:
             if args.check_empty_lines:
-                print(f"// {prefix}-EMPTY:")
+                print(f"{comm} {prefix}-EMPTY:")
                 next = True
             else:
                 next = False
@@ -93,8 +97,8 @@ def main():
 
         # Print the modified line
         if next:
-            print(f"// {prefix}-NEXT:  ", end="")
+            print(f"{comm} {prefix}-NEXT:  ", end="")
         else:
-            print(f"// {prefix}:       ", end="")
+            print(f"{comm} {prefix}:       ", end="")
             next = True
         print(line)

--- a/tests/filecheck/mlir.mlir
+++ b/tests/filecheck/mlir.mlir
@@ -2,6 +2,7 @@
 // RUN: filecheckize %s --strip-comments --check-empty-lines | filecheck %s --check-prefix WITH-EMPTY --match-full-lines
 // RUN: filecheckize %s --strip-comments --mlir-anonymize | filecheck %s --check-prefix ANONYMIZE --match-full-lines
 // RUN: filecheckize %s --strip-comments --xdsl-anonymize | filecheck %s --check-prefix XDSL-ANONYMIZE --match-full-lines
+// RUN: filecheckize %s --strip-comments --comments-prefix # | filecheck %s --check-prefix SHARP --match-full-lines
 
 func.func @arg_rec(%0 : !test.type<"int">) -> !test.type<"int"> {
     %1 = func.call @arg_rec(%0) : (!test.type<"int">) -> !test.type<"int">
@@ -47,3 +48,11 @@ func.func @arg_rec(%0 : !test.type<"int">) -> !test.type<"int"> {
 // XDSL-ANONYMIZE-NEXT:  // CHECK-NEXT:      %{{.*}} = arith.addi %name, %other_name : i32
 // XDSL-ANONYMIZE-NEXT:  // CHECK-NEXT:      func.return %{{.*}} : !test.type<"int">
 // XDSL-ANONYMIZE-NEXT:  // CHECK-NEXT:  }
+
+// SHARP:       # CHECK:       func.func @arg_rec(%0 : !test.type<"int">) -> !test.type<"int"> {
+// SHARP-NEXT:  # CHECK-NEXT:      %1 = func.call @arg_rec(%0) : (!test.type<"int">) -> !test.type<"int">
+// SHARP-NEXT:  # CHECK-NEXT:      %name = arith.constant : i32
+// SHARP-NEXT:  # CHECK-NEXT:      %other_name = arith.constant : i32
+// SHARP-NEXT:  # CHECK-NEXT:      %2 = arith.addi %name, %other_name : i32
+// SHARP-NEXT:  # CHECK-NEXT:      func.return %1 : !test.type<"int">
+// SHARP-NEXT:  # CHECK-NEXT:  }


### PR DESCRIPTION
- `--strip-comments` now takes an optional argument to strip comments given a custom comment prefix. (e.g., `--strip-comments #` will strip lines starting by `#` from the input). It defaults to `//` for compatibility.
- `--comment-prefix`, which was used for the above functionality, now enables choosing a comment prefix *for the output*